### PR TITLE
Update the maven compiler plugin version from 1.6 to 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
This pull request proposes an update to the Maven Compiler Plugin version from 1.6 to 1.7. The motivation behind this change stems from issues encountered during Jenkins job execution, where the previous plugin version (1.6) resulted in failures.

![maven-1 6-to-1 7](https://github.com/jhawithu/hello-world/assets/22823458/49d431e2-09cc-4df7-b16c-e4abe2a5741e)

The update to version 1.7 aims to address these failures and ensure the smooth execution of Jenkins jobs. By incorporating the latest version of the Maven Compiler Plugin, we anticipate resolving compatibility issues and benefiting from potential bug fixes and enhancements introduced in the newer release.

This pull request includes necessary modifications to the project configuration to accommodate the updated plugin version seamlessly. Prior to merging, it is recommended to conduct thorough testing to validate the stability and functionality of the Jenkins jobs with the new plugin version.

![success-build-1 7](https://github.com/jhawithu/hello-world/assets/22823458/800bb0e1-ca93-471e-a6bf-56120ffeb2ad)

Please to review the proposed changes and provide feedback or suggestions as needed. Additionally, any insights into specific issues encountered with the previous version or potential concerns with the update are welcomed for discussion within the pull request.

Thank you for your attention to this matter, and I look forward to collaboratively improving the project's development environment.

